### PR TITLE
chore(deps): update toolchain and dependencies to latest stable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.andvl1.engrade"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.andvl1.engrade"
@@ -41,10 +41,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
     }
@@ -55,6 +51,12 @@ android {
             excludes += "/META-INF/LICENSE.md"
             excludes += "/META-INF/LICENSE-notice.md"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,17 @@
 [versions]
-kotlin = "2.1.21"
-agp = "8.7.3"
-compose-bom = "2025.05.00"
-compose-compiler = "1.5.15"
-coroutines = "1.10.1"
-datastore = "1.1.1"
-decompose = "3.2.0"
-essenty = "2.2.0"
-lifecycle = "2.8.7"
-activity-compose = "1.9.3"
-serialization = "1.7.3"
-firebase-bom = "33.7.0"
-ksp = "2.1.21-2.0.1"
-room = "2.7.1"
+kotlin = "2.2.21"
+agp = "8.13.2"
+compose-bom = "2026.05.01"
+coroutines = "1.11.0"
+datastore = "1.2.1"
+decompose = "3.5.0"
+essenty = "2.5.0"
+lifecycle = "2.10.0"
+activity-compose = "1.13.0"
+serialization = "1.11.0"
+firebase-bom = "34.14.0"
+ksp = "2.2.21-2.0.5"
+room = "2.8.4"
 ultron = "2.6.2"
 
 [libraries]
@@ -30,7 +29,7 @@ compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 
 # AndroidX
-androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.15.0" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.18.0" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
@@ -53,11 +52,11 @@ firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 
 # Testing
 junit = { module = "junit:junit", version = "4.13.2" }
-androidx-test-runner = { module = "androidx.test:runner", version = "1.6.2" }
-androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.6.1" }
-androidx-test-core = { module = "androidx.test:core", version = "1.6.1" }
-androidx-test-rules = { module = "androidx.test:rules", version = "1.6.1" }
-androidx-test-ext-junit = { module = "androidx.test.ext:junit", version = "1.2.1" }
+androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.7.0" }
+androidx-test-core = { module = "androidx.test:core", version = "1.7.0" }
+androidx-test-rules = { module = "androidx.test:rules", version = "1.7.0" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version = "1.3.0" }
 ultron-android = { module = "com.atiurin:ultron-android", version.ref = "ultron" }
 ultron-compose = { module = "com.atiurin:ultron-compose-android", version.ref = "ultron" }
 ultron-allure = { module = "com.atiurin:ultron-allure", version.ref = "ultron" }
@@ -68,6 +67,6 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-google-services = { id = "com.google.gms.google-services", version = "4.4.2" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.2" }
+google-services = { id = "com.google.gms.google-services", version = "4.4.4" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.7" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.14.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Что

Обновление тулчейна и зависимостей до актуальных стабильных версий. Только версии — изменений в коде приложения нет (кроме миграции deprecated `kotlinOptions{}` DSL).

### Toolchain
| | было | стало |
|---|---|---|
| Gradle | 8.11.1 | 8.14.5 |
| AGP | 8.7.3 | 8.13.2 |
| Kotlin | 2.1.21 | 2.2.21 |
| KSP | 2.1.21-2.0.1 | 2.2.21-2.0.5 |
| compileSdk | 35 | 36 |

### Библиотеки
- Compose BOM 2025.05.00 → **2026.05.01**
- Room 2.7.1 → **2.8.4**
- Decompose 3.2.0 → **3.5.0**, Essenty 2.2.0 → **2.5.0**
- Lifecycle 2.8.7 → **2.10.0**, Activity Compose 1.9.3 → **1.13.0**
- core-ktx 1.15.0 → **1.18.0**, DataStore 1.1.1 → **1.2.1**
- Coroutines 1.10.1 → **1.11.0**, Serialization 1.7.3 → **1.11.0**
- Firebase BOM 33.7.0 → **34.14.0** (gms 4.4.4, crashlytics 3.0.7)
- AndroidX Test runner/core/rules → **1.7.0**, ext-junit → **1.3.0**, espresso → **3.7.0**

### Build config
- `kotlinOptions{}` (deprecated в AGP 8) → `kotlin { compilerOptions { jvmTarget } }`
- Удалён мёртвый catalog-энтри `compose-compiler`

## Сознательно отложено (trade-off)
- **Kotlin 2.3.x** — нет выпущенного KSP под 2.3 (нужен для Room). Последний доступный KSP — `2.2.21-2.0.5`. Поэтому максимум рабочего = Kotlin 2.2.21.
- **AGP 9.x** — требует миграции на built-in Kotlin (убрать `kotlin.android`, перестроить плагинную модель/KSP). Отдельной задачей.

## Verification
- ✅ `assembleDebug`
- ✅ unit-тесты
- ✅ `assembleDebugAndroidTest`
- ✅ `connectedDebugAndroidTest` — **33/33 passed** на pixel6_api34 (API 34)

## Известные warning'и (не из бампа, можно follow-up)
Старые Compose deprecations в коде: `Icons.Filled.Undo`/`ArrowBack` → `AutoMirrored`, `Divider` → `HorizontalDivider`. Не блокируют сборку.

> Ветка отведена от `master`, независима от PR #6 (tech-debt). При мерже одного — второй может потребовать rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)